### PR TITLE
add options in setup.py to allow nvcc arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,19 @@ class BuildExtension(torch.utils.cpp_extension.BuildExtension):
     def __init__(self, *args, **kwargs):
         super().__init__(use_ninja=False, *args, **kwargs)
 
+nvcc_args = []
+nvcc_flags_env = os.getenv("NVCC_FLAGS", "")
+if nvcc_flags_env != "":
+    nvcc_args.extend(nvcc_flags_env.split(" "))
+
+extra_compile_args["nvcc"] = nvcc_args
+
 setup(
   name="prefix_sum",
   author="Matt Dean, Lixin Xue",
   description="Parallel Prefix Sum on CUDA with Pytorch API",
   ext_modules=[
-    CUDAExtension('prefix_sum', ['prefix_sum.cu'])
+    CUDAExtension('prefix_sum', ['prefix_sum.cu'], extra_compile_args=extra_compile_args)
   ],
   cmdclass={"build_ext": BuildExtension},
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ nvcc_flags_env = os.getenv("NVCC_FLAGS", "")
 if nvcc_flags_env != "":
     nvcc_args.extend(nvcc_flags_env.split(" "))
 
+extra_compile_args = {}
 extra_compile_args["nvcc"] = nvcc_args
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import torch
+import os
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
 


### PR DESCRIPTION
This is needed when users want to compile the code for different GPU architectures in one go. 