### PR TITLE
Enable `PrefixSumCUDA` to work on system with multiple GPUs

### DIFF
--- a/prefix_sum.cu
+++ b/prefix_sum.cu
@@ -39,7 +39,7 @@
 // scan.cuh
 void sequential_scan(int* output, int* input, int length);
 void blockscan(int *output, int *input, int length, bool bcao);
-void scan(int *output, int *input, int length, bool bcao);
+void scan(int *output, int *input, int length, int device, bool bcao);
 
 void scanLargeDeviceArray(int *output, int *input, int length, bool bcao);
 void scanSmallDeviceArray(int *d_out, int *d_in, int length, bool bcao);
@@ -80,6 +80,7 @@ void PrefixSumCUDA(
     grid_off.contiguous().data_ptr<int>(),
     grid_cnt.contiguous().data_ptr<int>(),
     num_grids,
+    grid_cnt.device().index(),
     true
   );
 
@@ -132,7 +133,8 @@ void blockscan(int *d_out, int *d_in, int length, bool bcao) {
   return;
 }
 
-void scan(int *d_out, int *d_in, int length, bool bcao) {
+void scan(int *d_out, int *d_in, int length, int device, bool bcao) {
+    cudaSetDevice(device);
 	if (length > ELEMENTS_PER_BLOCK) {
 		scanLargeDeviceArray(d_out, d_in, length, bcao);
 	}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
 
 class BuildExtension(torch.utils.cpp_extension.BuildExtension):
     def __init__(self, *args, **kwargs):
-        super().__init__(use_ninja=False, *args, **kwargs)
+        super().__init__(use_ninja=True, *args, **kwargs)
 
 nvcc_args = []
 nvcc_flags_env = os.getenv("NVCC_FLAGS", "")


### PR DESCRIPTION
By default `PrefixSumCUDA` will always use `GPU0`. This is a problem when `at::Tensor` is not on `GPU0` (e.g. when the code uses multiple GPUs).

I have added `cudaSetDevice` to `scan` which now tells cuda to use the device that the `at::Tensor` is located on.

This code is backwards compatible (so won't break anyones code) and has been tested with a single gpu + multi gpu setup.